### PR TITLE
Added destroy method to clean up memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rallax.js",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Dead-simple parallax scrolling.",
   "main": "dist/rallax.js",
   "license": "MIT",

--- a/src/rallax.js
+++ b/src/rallax.js
@@ -37,6 +37,10 @@ class RallaxObj {
     this.active = true
   }
 
+  destroy() {
+    targets.splice(targets.indexOf(this), 1)
+  }
+
   getSpeed() {
     return this.speed
   }


### PR DESCRIPTION
In the case of single page apps such as mine, it is important to clean up old references to objects after the route has changed. This proposed change would allow the user to manually remove the references to unused rallax objects.